### PR TITLE
feat: subscribe and save view for variation product page

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@elasticpath/js-sdk": "5.0.0",
-    "@elasticpath/react-shopper-hooks": "0.14.0",
+    "@elasticpath/react-shopper-hooks": "0.14.2",
     "clsx": "^1.2.1",
     "cookies-next": "^4.0.0",
     "focus-visible": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@elasticpath/js-sdk": "5.0.0",
-    "@elasticpath/react-shopper-hooks": "0.14.2",
+    "@elasticpath/react-shopper-hooks": "0.14.3",
     "clsx": "^1.2.1",
     "cookies-next": "^4.0.0",
     "focus-visible": "^5.2.0",

--- a/src/app/(store)/products/[productId]/product-display.tsx
+++ b/src/app/(store)/products/[productId]/product-display.tsx
@@ -5,6 +5,7 @@ import { VariationProductDetail } from "../../../../components/product/variation
 import BundleProductDetail from "../../../../components/product/bundles/BundleProduct";
 import { ProductContext } from "../../../../lib/product-context";
 import SimpleProductDetail from "../../../../components/product/SimpleProduct";
+import { SubscriptionContext } from "../../../../lib/subscription-context";
 
 export function ProductProvider({
   children,
@@ -12,6 +13,8 @@ export function ProductProvider({
   children: ReactNode;
 }): ReactElement {
   const [isChangingSku, setIsChangingSku] = useState(false);
+  const [planId, setPlanId] = useState<string>();
+  const [offeringId, setOfferingId] = useState<string>();
 
   return (
     <ProductContext.Provider
@@ -20,7 +23,16 @@ export function ProductProvider({
         setIsChangingSku,
       }}
     >
-      {children}
+      <SubscriptionContext.Provider
+        value={{
+          planId,
+          offeringId,
+          setOfferingId,
+          setPlanId,
+        }}
+      >
+        {children}
+      </SubscriptionContext.Provider>
     </ProductContext.Provider>
   );
 }

--- a/src/components/product/subscriptions/ProductSubscribtion.tsx
+++ b/src/components/product/subscriptions/ProductSubscribtion.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+import {
+  ShopperProduct,
+  useAuthedAccountMember,
+} from "@elasticpath/react-shopper-hooks";
+import { SubscriptionOffering } from "@elasticpath/js-sdk";
+import { getOfferings } from "../../../services/subscriptions";
+import { getEpccImplicitClient } from "../../../lib/epcc-implicit-client";
+import { RadioGroup, RadioGroupItem } from "../../radio-group/RadioGroup";
+import { Label } from "../../label/Label";
+import ProductSubscriptionOption from "./ProductSubscribtionOption";
+import { SubscriptionContext } from "../../../lib/subscription-context";
+import Price from "../Price";
+
+interface IProductSubscriptions {
+  product: ShopperProduct["response"];
+}
+
+const ProductSubscriptions = ({
+  product,
+}: IProductSubscriptions): JSX.Element => {
+  const client = getEpccImplicitClient();
+
+  const oneTimePurchasesKey = "one-time";
+  const {
+    id: productId,
+    meta: { display_price },
+  } = product;
+
+  const { setPlanId, setOfferingId } = useContext(SubscriptionContext);
+  const [purchaseOption, setPurchaseOption] = useState<string>();
+  const [offerings, setOfferings] = useState<SubscriptionOffering[]>();
+
+  const getSubscriptionData = useCallback(async (): Promise<void> => {
+    try {
+      const offeringsResponse = await getOfferings(client, {
+        eq: { "products.external_ref": productId },
+      });
+
+      setOfferings(offeringsResponse.data);
+    } catch (e) {
+      console.log(e);
+    }
+  }, []);
+
+  useEffect(() => {
+    getSubscriptionData();
+  }, [getSubscriptionData]);
+
+  if (!offerings) {
+    return null;
+  }
+
+  const handlePurchaseOptionChange = (option: string) => {
+    setPurchaseOption(option);
+    if (setOfferingId !== oneTimePurchasesKey) {
+      setOfferingId(option);
+    } else {
+      setOfferingId();
+      setPlanId();
+    }
+  };
+
+  return (
+    <RadioGroup
+      className="space-y-4"
+      onValueChange={handlePurchaseOptionChange}
+      defaultValue={oneTimePurchasesKey}
+    >
+      {offerings.map((offering) => (
+        <ProductSubscriptionOption
+          key={offering.id}
+          offering={offering}
+          selected={purchaseOption === offering.id}
+        />
+      ))}
+      <div className="p-4 border rounded-lg max-w-sm">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <RadioGroupItem
+              value={oneTimePurchasesKey}
+              id={oneTimePurchasesKey}
+            />
+            <Label
+              className="hover:cursor-pointer font-semibold text-base"
+              htmlFor={oneTimePurchasesKey}
+            >
+              One-time purchase
+            </Label>
+          </div>
+          {display_price && (
+            <Price
+              price={display_price.without_tax.formatted}
+              currency={display_price.without_tax.currency}
+              size="text-2xl"
+            />
+          )}
+        </div>
+      </div>
+    </RadioGroup>
+  );
+};
+
+export default ProductSubscriptions;

--- a/src/components/product/subscriptions/ProductSubscribtion.tsx
+++ b/src/components/product/subscriptions/ProductSubscribtion.tsx
@@ -53,11 +53,11 @@ const ProductSubscriptions = ({
 
   const handlePurchaseOptionChange = (option: string) => {
     setPurchaseOption(option);
-    if (setOfferingId !== oneTimePurchasesKey) {
+    if (option !== oneTimePurchasesKey) {
       setOfferingId(option);
     } else {
-      setOfferingId();
-      setPlanId();
+      setOfferingId(undefined);
+      setPlanId(undefined);
     }
   };
 
@@ -92,7 +92,7 @@ const ProductSubscriptions = ({
             <Price
               price={display_price.without_tax.formatted}
               currency={display_price.without_tax.currency}
-              size="text-2xl"
+              size="text-base	text-gray-700 font-medium mt-0"
             />
           )}
         </div>

--- a/src/components/product/subscriptions/ProductSubscribtionOption.tsx
+++ b/src/components/product/subscriptions/ProductSubscribtionOption.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+import {
+  SubscriptionOffering,
+  SubscriptionOfferingPlan,
+} from "@elasticpath/js-sdk";
+import { getOfferingPlans } from "../../../services/subscriptions";
+import { getEpccImplicitClient } from "../../../lib/epcc-implicit-client";
+import { RadioGroupItem } from "../../radio-group/RadioGroup";
+import { Label } from "../../label/Label";
+import { useAddSubscriptionItemToCart } from "@elasticpath/react-shopper-hooks";
+import { SubscriptionContext } from "../../../lib/subscription-context";
+
+interface IProductSubscriptionOption {
+  offering: SubscriptionOffering;
+  selected: boolean;
+}
+
+const ProductSubscriptionOption = ({
+  offering,
+  selected,
+}: IProductSubscriptionOption): JSX.Element => {
+  const client = getEpccImplicitClient();
+  const { planId, setPlanId } = useContext(SubscriptionContext);
+
+  const [plans, setPlans] = useState<SubscriptionOfferingPlan[]>([]);
+
+  const getPlansData = useCallback(async (): Promise<void> => {
+    try {
+      const offeringPlansResponse = await getOfferingPlans(offering.id, client);
+      setPlans(offeringPlansResponse.data);
+    } catch (e) {
+      console.log(e);
+    }
+  }, []);
+
+  useEffect(() => {
+    getPlansData();
+  }, [getPlansData]);
+
+  return (
+    <div className="p-4 border rounded-lg max-w-sm">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <RadioGroupItem value={offering.id} id={offering.id} />
+          <Label
+            className="hover:cursor-pointer text-red-500 font-semibold text-base"
+            htmlFor={offering.id}
+          >
+            {offering.attributes.name}
+          </Label>
+        </div>
+        <span className="text-gray-700 font-medium">
+          {_extractPriceFromPlansArray(planId, plans)}
+        </span>
+      </div>
+
+      {selected && (
+        <div className="my-4">
+          <select
+            value={planId ?? "default"}
+            onChange={(e) => setPlanId(e.target.value)}
+            className="w-full border-gray-300 rounded-md"
+          >
+            <option value="default" disabled>
+              Select your option
+            </option>
+            {plans?.map((plan) => (
+              <option key={plan.id} value={plan.id}>
+                {plan.attributes.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const _extractPriceFromPlansArray = (
+  planId: string,
+  plansList: SubscriptionOfferingPlan[],
+): string => {
+  const plan = plansList.find((plan) => plan.id === planId);
+  // TODO: Update SDK types, handle multiple price types
+  return plan?.meta?.display_price?.with_tax?.formatted ?? "";
+};
+
+export default ProductSubscriptionOption;

--- a/src/components/product/variations/VariationProduct.tsx
+++ b/src/components/product/variations/VariationProduct.tsx
@@ -76,7 +76,10 @@ export function VariationProductContainer(): JSX.Element {
             <ProductSubscriptions product={response} />
             {extensions && <ProductExtensions extensions={extensions} />}
             <StatusButton
-              disabled={product.kind === "base-product"}
+              disabled={
+                product.kind === "base-product" ||
+                (offeringId ? !planId : false)
+              }
               type="button"
               onClick={handleAddToCart}
               status={isPending ? "loading" : "idle"}

--- a/src/lib/subscription-context.ts
+++ b/src/lib/subscription-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+import { SubscriptionContextState } from "./types/product-types";
+
+export const SubscriptionContext =
+  createContext<SubscriptionContextState | null>(null);

--- a/src/lib/types/product-types.ts
+++ b/src/lib/types/product-types.ts
@@ -1,5 +1,7 @@
 import type { ProductResponse, File } from "@elasticpath/js-sdk";
 import type { Dispatch, SetStateAction } from "react";
+import { CartAddSubscriptionItemReq } from "@elasticpath/react-shopper-hooks";
+import { SubscriptionContext } from "../cart-product-type-context";
 
 export type IdentifiableBaseProduct = ProductResponse & {
   id: string;
@@ -28,4 +30,16 @@ export interface ProductResponseWithImage extends ProductResponse {
 
 export interface ProductImageObject {
   [key: string]: File;
+}
+
+export interface CartProductTypeContext {
+  isChangingSku: boolean;
+  setIsChangingSku: Dispatch<SetStateAction<boolean>>;
+}
+
+export interface SubscriptionContextState {
+  offeringId?: string;
+  planId?: string;
+  setOfferingId: Dispatch<SetStateAction<string>>;
+  setPlanId: Dispatch<SetStateAction<string>>;
 }

--- a/src/services/subscriptions.ts
+++ b/src/services/subscriptions.ts
@@ -1,0 +1,28 @@
+import type {
+  ResourceList,
+  ResourcePage,
+  SubscriptionOffering,
+  SubscriptionOfferingFilter,
+  SubscriptionOfferingPlan,
+} from "@elasticpath/js-sdk";
+import { ElasticPath } from "@elasticpath/js-sdk";
+
+export async function getOfferings(
+  client: ElasticPath,
+  filters?: SubscriptionOfferingFilter,
+): Promise<ResourcePage<SubscriptionOffering>> {
+  const offeringRequest = client.SubscriptionOfferings;
+
+  if (filters) {
+    offeringRequest.Filter(filters);
+  }
+
+  return offeringRequest.All();
+}
+
+export async function getOfferingPlans(
+  offeringId: string,
+  client: ElasticPath,
+): Promise<ResourceList<SubscriptionOfferingPlan>> {
+  return client.SubscriptionOfferings.GetAttachedPlans(offeringId);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,21 +1042,34 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@elasticpath/react-shopper-hooks@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@elasticpath/react-shopper-hooks/-/react-shopper-hooks-0.12.0.tgz#0e3f97b590ffa2ca46f85a3c95187009e6f3e52c"
-  integrity sha512-HA1SmH17F3C13niBvaerzdZA+gU3RYyKn7UKDZULQsNYgDycDwSs/zjqhSi0Rmwca1I+t1xV8I5wjyV13vgD8Q==
+"@elasticpath/js-sdk@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@elasticpath/js-sdk/-/js-sdk-5.0.0.tgz#90af4079e91ae60b4c606cea35779868c2747064"
+  integrity sha512-fPtFrolcaQyjHD4NhWyPXV8NMXYWSA3oSlKYvWbbhkSuHsy9mDyDX1EBWmhgKrAXhydxCnngqjJpf4QrxlWSEw==
   dependencies:
-    "@elasticpath/shopper-common" "0.3.0"
+    cross-fetch "^3.1.5"
+    es6-promise "^4.0.5"
+    form-data "^4.0.0"
+    inflected "^2.0.1"
+    js-cookie "^3.0.1"
+    node-localstorage "^2.1.6"
+    throttled-queue "^2.1.4"
+
+"@elasticpath/react-shopper-hooks@0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@elasticpath/react-shopper-hooks/-/react-shopper-hooks-0.14.2.tgz#a272c6016de1dbb7942923994399b51dce7386c0"
+  integrity sha512-MWjKjt7CcILYdKNfzSd7SMszJiify3TmjB7S1uplXtiRv24s6jv2v+5atII9dC09Kr0J8IOpo/huj5CXlXtiKw==
+  dependencies:
+    "@elasticpath/shopper-common" "0.4.0"
     js-cookie "^3.0.5"
     jwt-decode "^3.1.2"
 
-"@elasticpath/shopper-common@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@elasticpath/shopper-common/-/shopper-common-0.3.0.tgz#0d661353982866a476e8aeb9aeae81d01139987a"
-  integrity sha512-DmK5PPPn2y6sMc7XdmEp7MRIlQZh+iJqM3mIgwcqBjqgpchgkL8AVZqBxxJktLKPSBn0e1LKWEwHE2jLpVI4QA==
+"@elasticpath/shopper-common@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@elasticpath/shopper-common/-/shopper-common-0.4.0.tgz#4255b72f5a1f8c4397ddca7379ec07ac79f7f650"
+  integrity sha512-ZAKp2HGCvbXzfDprbjCBnmSbxGfrlJ9yhmfOMK22jI5yBp37moGV+Wk7RMS4ij6fngMDCLtgOp6ao1+C9mKtbQ==
   dependencies:
-    "@moltin/sdk" "28.12.0"
+    "@elasticpath/js-sdk" "5.0.0"
     tslib "^2.6.2"
 
 "@esbuild/aix-ppc64@0.21.5":
@@ -1485,19 +1498,6 @@
   integrity sha512-6RU5ol2lDtO8bD9Yxe6CZkl0DArdv0qkuoZC+ZwowU+cdRlVE1157wjCmlA5Rsf1Xc/brACnsZa5PZpEDfTFFg==
   dependencies:
     make-plural "^7.0.0"
-
-"@moltin/sdk@28.12.0":
-  version "28.12.0"
-  resolved "https://registry.yarnpkg.com/@moltin/sdk/-/sdk-28.12.0.tgz#57e231a07359365527c6b9370358df1a8b49daf3"
-  integrity sha512-dSR1TKxAVBLu7VqXW7mVcvl0/fRP0DnCUpwyfvPnsytnlAXVrs1NrScsjnBZypLty1ytJaz0QsMziIv6qPR/TA==
-  dependencies:
-    cross-fetch "^3.1.5"
-    es6-promise "^4.0.5"
-    form-data "^4.0.0"
-    inflected "^2.0.1"
-    js-cookie "^3.0.1"
-    node-localstorage "^2.1.6"
-    throttled-queue "^2.1.4"
 
 "@next/bundle-analyzer@^14.0.0":
   version "14.2.5"
@@ -2167,17 +2167,17 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
-"@tanstack/query-core@5.51.21":
-  version "5.51.21"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.51.21.tgz#a510469c6c30d3de2a8b8798e340169a4b0fd08f"
-  integrity sha512-POQxm42IUp6n89kKWF4IZi18v3fxQWFRolvBA6phNVmA8psdfB1MvDnGacCJdS+EOX12w/CyHM62z//rHmYmvw==
+"@tanstack/query-core@5.52.0":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.52.0.tgz#44070b2d6eb58c3a5ce2788471d842e932294a87"
+  integrity sha512-U1DOEgltjUwalN6uWYTewSnA14b+tE7lSylOiASKCAO61ENJeCq9VVD/TXHA6O5u9+6v5+UgGYBSccTKDoyMqw==
 
-"@tanstack/react-query@^5.17.15":
-  version "5.51.23"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.51.23.tgz#83c223f4cb6054b206de8856b73ca7e41a63ba1f"
-  integrity sha512-CfJCfX45nnVIZjQBRYYtvVMIsGgWLKLYC4xcUiYEey671n1alvTZoCBaU9B85O8mF/tx9LPyrI04A6Bs2THv4A==
+"@tanstack/react-query@^5.51.23":
+  version "5.52.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.52.0.tgz#671478798f1873983807cf6f62b140c817b3cc9f"
+  integrity sha512-T8tLZdPEopSD3A1EBZ/sq7WkI76pKLKKiT82F486K8wf26EPgYCdeiSnJfuayssdQjWwLQMQVl/ROUBNmlWgCQ==
   dependencies:
-    "@tanstack/query-core" "5.51.21"
+    "@tanstack/query-core" "5.52.0"
 
 "@tanstack/react-virtual@^3.0.0-beta.60":
   version "3.8.6"
@@ -2313,17 +2313,25 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
 
-"@types/react-dom@^18.0.0", "@types/react-dom@^18.2.14":
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.3.0":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.2.33":
+"@types/react@*":
   version "18.3.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
   integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.3.1":
+  version "18.3.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.4.tgz#dfdd534a1d081307144c00e325c06e00312c93a3"
+  integrity sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -5713,7 +5721,7 @@ react-device-detect@^2.2.2:
   dependencies:
     ua-parser-js "^1.0.33"
 
-react-dom@^18.2.0:
+react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
   integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
@@ -5781,7 +5789,7 @@ react-toastify@^9.1.3:
   dependencies:
     clsx "^1.1.1"
 
-react@^18.2.0:
+react@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
   integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
@@ -6184,6 +6192,7 @@ string-argv@0.3.2:
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,10 +1055,10 @@
     node-localstorage "^2.1.6"
     throttled-queue "^2.1.4"
 
-"@elasticpath/react-shopper-hooks@0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@elasticpath/react-shopper-hooks/-/react-shopper-hooks-0.14.2.tgz#a272c6016de1dbb7942923994399b51dce7386c0"
-  integrity sha512-MWjKjt7CcILYdKNfzSd7SMszJiify3TmjB7S1uplXtiRv24s6jv2v+5atII9dC09Kr0J8IOpo/huj5CXlXtiKw==
+"@elasticpath/react-shopper-hooks@0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@elasticpath/react-shopper-hooks/-/react-shopper-hooks-0.14.3.tgz#23df980b23f4fe409e5a5402a3bbe565f9e1c41d"
+  integrity sha512-51u22RkfFbnJp+PyNXnV2RdSFKFy+Suyiej//tRSD7wbW5FR805ldx/3jgcvurAQ+9ltDjQp7Qvx11NFUaXzwg==
   dependencies:
     "@elasticpath/shopper-common" "0.4.0"
     js-cookie "^3.0.5"


### PR DESCRIPTION
**Changes:**
   - Added `SubscriptionContext` to manage subscription state (`planId`, `offeringId`) across components.
   - Created `ProductSubscriptions` component to display subscription options.
   - Created `ProductSubscriptionOption` component to handle individual subscription offerings.
   - Integrated `ProductSubscriptions` into `VariationProductDetail` to allow users to select subscription options.
   - Updated the `ADD TO CART` button to handle both one-time purchases and subscription products.
   - Added `subscriptions.ts` to handle API requests related to subscription offerings and plans.
